### PR TITLE
fix: add hreflang to Link type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface Link {
     type?: string;
     title?: HTMLLinkElement['title'];
     crossOrigin?: '' | 'anonymous' | 'use-credentials';
+    hreflang?: HTMLLinkElement['hreflang'];
 }
 
 export interface Icon {


### PR DESCRIPTION
Hello! Changed the type for `Link` interface. This is necessary for the SEO https://developers.google.com/search/docs/specialty/international/localized-versions