### PR TITLE
fix: do not render metrika for empty array

### DIFF
--- a/src/plugins/yandex-metrika/index.ts
+++ b/src/plugins/yandex-metrika/index.ts
@@ -34,6 +34,10 @@ export function renderMetrika(params: MetrikaPluginOptions, utils: RenderHelpers
         counters = [counters];
     }
 
+    if (counters.length === 0) {
+        return '';
+    }
+
     counters = counters.map((config) => Object.assign({}, defaultCounterConfig, config || {}));
 
     if (counters.some((config) => !config.id)) {


### PR DESCRIPTION
Otherwise script will be rendered with empty counters