### PR TITLE
feat: dynamic manifest path in layout plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@gravity-ui/app-layout",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "htmlescape": "^1.1.1"

--- a/src/plugins/layout/index.ts
+++ b/src/plugins/layout/index.ts
@@ -1,6 +1,6 @@
 import htmlescape from 'htmlescape';
 
-import type {Plugin} from '../../types.js';
+import type {CommonOptions, Plugin} from '../../types.js';
 
 import {getAbsoluteUrl, getJSONContent} from './helpers.js';
 import type {LayoutPluginOptions, Manifest} from './types.js';
@@ -9,7 +9,7 @@ export type {LayoutPluginOptions} from './types.js';
 
 export interface LayoutInitOptions {
     publicPath?: string;
-    manifest: string;
+    manifest: string | ((commonOptions: CommonOptions) => string);
 }
 export function createLayoutPlugin({
     publicPath = '/build/',
@@ -17,12 +17,14 @@ export function createLayoutPlugin({
 }: LayoutInitOptions): Plugin<LayoutPluginOptions, 'layout'> {
     return {
         name: 'layout',
-        apply({options, renderContent}) {
+        apply({options, renderContent, commonOptions}) {
             if (!options) {
                 return;
             }
 
-            const manifestFile: Manifest = getJSONContent(manifest, (err) => {
+            const manifestPath = typeof manifest === 'string' ? manifest : manifest(commonOptions);
+
+            const manifestFile: Manifest = getJSONContent(manifestPath, (err) => {
                 console.error('Unable to read manifest file', err);
                 process.exit(1);
             });

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface Icon {
 
 export type Meta = {name: string; content: string};
 
-interface CommonOptions {
+export interface CommonOptions {
     title: string;
     lang?: string;
     isMobile?: boolean;


### PR DESCRIPTION
Support for dynamic manifest path in Layout Plugin.
This can be useful if you need to use a different manifest depending on the current language.

For example:
```
createLayoutPlugin({
    manifest: (options) => `assets-manifest.${options.lang}.json`,
})
```