### PR TITLE
fix(RenderBodyContent): make renderBodyContent ssr-friendly

### DIFF
--- a/src/utils/renderBodyContent.ts
+++ b/src/utils/renderBodyContent.ts
@@ -3,9 +3,7 @@ import type {BodyContent} from '../types.js';
 export function renderBodyContent(content: BodyContent): string {
     return `
         ${content.beforeRoot.join('\n')}
-        <div id="root">
-            ${content.root ?? ''}
-        </div>
+        <div id="root">${content.root ?? ''}</div>
         ${content.afterRoot.join('\n')}
     `.trim();
 }


### PR DESCRIPTION
Problem is that if you use app-layout to render SSR pages, it does not rehydrate properly because of additional whitespaces present inside `div` tag for root node.

App-layout produces:
```html
<div id="root">
    <div>app content</div>
</div>
```

React.hydrateRoot() expects:
```html
<div id="root"><div>app content</div></div>
```