### PR TITLE
feat: add support for <base> tag in rendered HTML

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -43,6 +43,8 @@ interface RenderParams<Data, Plugins> {
   icon?: Icon;
   // nonce to be set on the appropriate tags
   nonce?: string;
+  // base tag attributes
+  base?: Base;
 
   // common options
   // Page title
@@ -83,6 +85,32 @@ interface RenderParams<Data, Plugins> {
   // plugins options
   pluginsOptions?: Partial<PluginsOptions<Plugins>>;
 }
+```
+
+### `Base`
+
+Описывает тег `base`:
+
+```typescript
+interface Base {
+  href?: string;
+  target?: HTMLBaseElement['target'];
+}
+```
+
+Например:
+
+```js
+renderLayout({
+  title: 'Home page',
+  base: {target: '_top'},
+});
+```
+
+Будет выглядеть следующим образом:
+
+```html
+<base target="_top" />
 ```
 
 ### `Meta`
@@ -252,6 +280,7 @@ interface CommonOptions {
 }
 
 export interface HeadContent {
+  base?: Base;
   scripts: Script[];
   helpers: RenderHelpers;
   links: Link[];

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ interface RenderParams<Data, Plugins> {
   icon?: Icon;
   // nonce to be set on the appropriate tags
   nonce?: string;
+  // base tag attributes
+  base?: Base;
 
   // common options
   // Page title
@@ -83,6 +85,32 @@ interface RenderParams<Data, Plugins> {
   // plugins options
   pluginsOptions?: Partial<PluginsOptions<Plugins>>;
 }
+```
+
+### Base
+
+Describes `base` tag:
+
+```typescript
+interface Base {
+  href?: string;
+  target?: HTMLBaseElement['target'];
+}
+```
+
+Example:
+
+```js
+renderLayout({
+  title: 'Home page',
+  base: {target: '_top'},
+});
+```
+
+Will be rendered as:
+
+```html
+<base target="_top" />
 ```
 
 ### Meta
@@ -252,6 +280,7 @@ interface CommonOptions {
 }
 
 export interface HeadContent {
+  base?: Base;
   scripts: Script[];
   helpers: RenderHelpers;
   links: Link[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from './plugins/index.js';
 
 export type {
+    Base,
     Plugin,
     Icon,
     Link,

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -16,6 +16,24 @@ test('should allow `<html>` attributes override', () => {
     expect(createRenderFunction([dirPlugin()])({title: 'Foobar'})).toMatch('<html dir="ltr">');
 });
 
+test('should render `<base>` tag with target', () => {
+    const html = createRenderFunction()({title: 'Foobar', base: {target: '_top'}});
+    expect(html).toMatch('<base target="_top">');
+});
+
+test('should render `<base>` tag with href and target', () => {
+    const html = createRenderFunction()({
+        title: 'Foobar',
+        base: {href: 'https://example.com/', target: '_top'},
+    });
+    expect(html).toMatch('<base href="https://example.com/" target="_top">');
+});
+
+test('should not render `<base>` tag when base is not provided', () => {
+    const html = createRenderFunction()({title: 'Foobar'});
+    expect(html).not.toMatch('<base');
+});
+
 test('should render root content', () => {
     expect(createRenderFunction()({title: 'Foobar'})).toMatch(/<div id="root">\s*<\/div>/);
     expect(createRenderFunction()({title: 'Foobar', bodyContent: {root: 'content'}})).toMatch(

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export interface BodyContent {
     afterRoot: string[];
 }
 
-export interface RenderContent extends HeadContent {
+export interface RenderContent extends Required<HeadContent> {
     htmlAttributes: Attributes;
     bodyContent: BodyContent;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,11 @@ export interface Icon {
 
 export type Meta = {name: string; content: string};
 
+export interface Base {
+    href?: string;
+    target?: HTMLBaseElement['target'];
+}
+
 export interface CommonOptions {
     title: string;
     lang?: string;
@@ -39,6 +44,7 @@ export interface CommonOptions {
 }
 
 export interface HeadContent {
+    base?: Base;
     scripts: Script[];
     helpers: RenderHelpers;
     links: Link[];
@@ -84,6 +90,7 @@ export interface RenderParams<Data, Plugins extends Plugin[] = []> extends Commo
     data?: Data;
     icon?: Icon;
     nonce?: string;
+    base?: Base;
     // content
     htmlAttributes?: Attributes;
     meta?: Meta[];

--- a/src/utils/generateRenderContent.ts
+++ b/src/utils/generateRenderContent.ts
@@ -71,13 +71,14 @@ export function generateRenderContent<Plugins extends Plugin[], Data>(
         links.unshift({rel: 'icon', type: icon.type, sizes: icon.sizes, href: icon.href});
     }
 
-    const {lang, isMobile, title, pluginsOptions = {}} = params;
+    const {lang, isMobile, title, base, pluginsOptions = {}} = params;
     for (const plugin of plugins ?? []) {
         plugin.apply({
             options: hasProperty(pluginsOptions, plugin.name)
                 ? pluginsOptions[plugin.name]
                 : undefined,
             renderContent: {
+                base,
                 htmlAttributes,
                 meta,
                 links,
@@ -99,6 +100,7 @@ export function generateRenderContent<Plugins extends Plugin[], Data>(
     }
 
     return {
+        base,
         htmlAttributes,
         meta,
         links,

--- a/src/utils/generateRenderContent.ts
+++ b/src/utils/generateRenderContent.ts
@@ -71,7 +71,7 @@ export function generateRenderContent<Plugins extends Plugin[], Data>(
         links.unshift({rel: 'icon', type: icon.type, sizes: icon.sizes, href: icon.href});
     }
 
-    const {lang, isMobile, title, base, pluginsOptions = {}} = params;
+    const {lang, isMobile, title, base = {}, pluginsOptions = {}} = params;
     for (const plugin of plugins ?? []) {
         plugin.apply({
             options: hasProperty(pluginsOptions, plugin.name)

--- a/src/utils/renderHeadContent.ts
+++ b/src/utils/renderHeadContent.ts
@@ -1,11 +1,21 @@
 import type {HeadContent} from '../types.js';
 
 export function renderHeadContent(content: HeadContent): string {
-    const {scripts, helpers, links, meta, styleSheets, inlineStyleSheets, inlineScripts, title} =
-        content;
+    const {
+        base,
+        scripts,
+        helpers,
+        links,
+        meta,
+        styleSheets,
+        inlineStyleSheets,
+        inlineScripts,
+        title,
+    } = content;
 
     return `
         <meta charset="utf-8">
+        ${base ? `<base ${helpers.attrs({...base})}>` : ''}
         <title>${title}</title>
         ${[
             ...scripts.map(({src, crossOrigin}) =>

--- a/src/utils/renderHeadContent.ts
+++ b/src/utils/renderHeadContent.ts
@@ -13,9 +13,11 @@ export function renderHeadContent(content: HeadContent): string {
         title,
     } = content;
 
+    const baseAttrs = base ? helpers.attrs({...base}) : '';
+
     return `
         <meta charset="utf-8">
-        ${base ? `<base ${helpers.attrs({...base})}>` : ''}
+        ${baseAttrs ? `<base ${baseAttrs}>` : ''}
         <title>${title}</title>
         ${[
             ...scripts.map(({src, crossOrigin}) =>


### PR DESCRIPTION
Add a new `base` option to `RenderParams` that allows setting `<base href="..." target="...">` in the document `<head>`.

- Add `Base` interface with optional `href` and `target` fields
- Add `base?` to `HeadContent` and `RenderParams` interfaces
- Wire `base` through `generateRenderContent` (including plugin access)
- Render `<base>` tag after `<meta charset>` and before `<title>`
- Export `Base` type from package index
- Add tests for base tag rendering
- Document in README.md and README-ru.md